### PR TITLE
Github Actionsのupload artifactsのパスをワイルドカードにする.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -43,4 +43,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: NuGetPackage
-        path: ./build/Net.Kuropen.EasyConstructor.0.1.0.nupkg
+        path: ./build/Net.Kuropen.EasyConstructor.*.nupkg


### PR DESCRIPTION
パッケージのバージョンを上げた際にartifactがバージョンまで指定していたためアップロードできない問題があった。これを解消するためにワイルドカードに変更する。